### PR TITLE
Handle log subscriber symbol logger level

### DIFF
--- a/activesupport/lib/active_support/log_subscriber.rb
+++ b/activesupport/lib/active_support/log_subscriber.rb
@@ -96,6 +96,10 @@ module ActiveSupport
         end
       end
 
+      def logger_level
+        @logger_level ||= logger.level.is_a?(Symbol) ? ::Logger.const_get(logger.level.upcase) : logger.level
+      end
+
       def attach_to(...) # :nodoc:
         result = super
         set_event_levels
@@ -139,8 +143,12 @@ module ActiveSupport
       LogSubscriber.logger
     end
 
+    def logger_level
+      LogSubscriber.logger_level
+    end
+
     def silenced?(event)
-      logger.nil? || logger.level > @event_levels.fetch(event, Float::INFINITY)
+      logger.nil? || logger_level > @event_levels.fetch(event, Float::INFINITY)
     end
 
     def call(event)

--- a/activesupport/test/log_subscriber_test.rb
+++ b/activesupport/test/log_subscriber_test.rb
@@ -82,6 +82,14 @@ class SyncLogSubscriberTest < ActiveSupport::TestCase
     assert_equal "cool, isn't it?", @logger.logged(:info).last
   end
 
+  def test_logger_level
+    @logger.level = :debug
+    ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
+    instrument "some_event.my_log_subscriber"
+    wait
+    assert_equal %w(some_event.my_log_subscriber), @logger.logged(:info)
+  end
+
   def test_event_is_sent_to_the_registered_class
     ActiveSupport::LogSubscriber.attach_to :my_log_subscriber, @log_subscriber
     instrument "some_event.my_log_subscriber"


### PR DESCRIPTION
### Motivation / Background

https://github.com/rails/rails/pull/45796 introduced a change to ActiveSupport::LogSubscriber expecting its Logger’s level to always be an integer. It would be helpful when using custom loggers to be able to continue using symbol based levels. I found this issue using the `semantic_logger` [gem](https://github.com/reidmorrison/semantic_logger) with `ActiveRecord::Base.logger = SemanticLogger["ActiveRecord"]` in an initializer.

Steps To Reproduce:
With Ruby 3.0.4, make a new rails repo with the main rails branch
add rspec-rails and semantic_logger gem
Run rails generate rspec:install
Add ActiveRecord::Base.logger = SemanticLogger["ActiveRecord"] to semantic_logger_error/config/initializers/logging.rb
Create a test model with specs - rails generate model Article title:string
Run rspec





<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
-->

This Pull Request has been created because [REPLACE ME]

### Detail

This Pull Request memoizes the logger level in the `ActiveSupport::LogSubscriber` class in a new `logger_level` function. The memoize step retrieves the relevant integer constant if the logger level is a symbol.

### Additional information

Steps to reproduce from scratch:
* With Ruby 3.0.4, make a new rails repo with the main rails branch
* Add `rspec-rails` and `semantic_logger` gems to `Gemfile`
* Run `rails generate rspec:install`
* Add `ActiveRecord::Base.logger = SemanticLogger["ActiveRecord"]` to `semantic_logger_error/config/initializers/logging.rb`
* Create a test model with specs - `rails generate model Article title:string`
* Run rspec

### Checklist

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
